### PR TITLE
add .npmignore to hyperzsh

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+screenshots
+gulpfile.js


### PR DESCRIPTION
Just a small .npmignore to lighten the load of the screenshots/gulpfile.js from the npm install footprint of this module. 

This is of really low importance in terms of criticality.