### PR TITLE
fix: _git_time_since_commit

### DIFF
--- a/hyperzsh.zsh-theme
+++ b/hyperzsh.zsh-theme
@@ -65,7 +65,7 @@ function _git_time_since_commit() {
     sub_hours=$((hours % 24))
     sub_minutes=$((minutes % 60))
 
-    if [ $hours -gt 24 ]; then
+    if [ $hours -ge 24 ]; then
       commit_age="${days}d "
     elif [ $minutes -gt 60 ]; then
       commit_age="${sub_hours}h${sub_minutes}m "


### PR DESCRIPTION
fixes an issue where the `_git_time_since_commit` function was returning `0hXm` for 1 day, 0 hours, X minutes.

This resolves the issue by checking if the age of the commit in hours is greater than ***or equal to*** 24, and returns `1d`.